### PR TITLE
Increase max nesting level to 256

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,5 +15,5 @@ php_xdebug_remote_log: /tmp/xdebug.log
 
 php_xdebug_idekey: sublime.xdebug
 
-php_xdebug_max_nesting_level: 100
+php_xdebug_max_nesting_level: 256
 


### PR DESCRIPTION
January 18 this year xdebug kicked the default up to 256 - http://bugs.xdebug.org/view.php?id=1100.