### PR TITLE
Fix xdebug in PHP 5.6

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -45,6 +45,18 @@
     group: root
     mode: 0644
   notify: restart webserver
+  
+- name: Check for separate apache2 xdebug.ini
+  stat: path=/etc/php5/apache2/conf.d/xdebug.ini
+  register: php_apache_xdebug_ini
+
+- name: Symlink xdebug.ini into separate Apache2 directory.
+  file:
+    src: "{{ php_extension_conf_path }}/xdebug.ini"
+    dest: /etc/php5/apache2/conf.d/xdebug.ini
+    state: link
+  when: php_apache_xdebug_ini.stat.exists is defined and not php_apache_xdebug_ini.stat.exists
+  notify: restart webserver
 
 - name: Check for separate cli php conf.d directory.
   stat: path=/etc/php5/cli/conf.d
@@ -57,3 +69,4 @@
     dest: /etc/php5/cli/conf.d/xdebug.ini
     state: link
   when: php_xdebug_cli_enable and php_cli_path.stat.isdir is defined and php_cli_path.stat.isdir
+  notify: restart webserver


### PR DESCRIPTION
In previous PHP version `/etc/php5/apache2/conf.d` is pointed to `/etc/php5/conf.d` via symlink.
In PHP 5.6 `/etc/php5/apache2/conf.d` and `/etc/php5/cli/conf.d` are not symlinks to `/etc/php5/conf.d`. They're separate directories.