### PR TITLE
xdebug settings for variables

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -18,3 +18,6 @@ php_xdebug_idekey: sublime.xdebug
 
 php_xdebug_max_nesting_level: 256
 
+php_xdebug_var_display_max_children: 128
+php_xdebug_var_display_max_data: 512
+php_xdebug_var_display_max_depth: 3

--- a/templates/xdebug.ini.j2
+++ b/templates/xdebug.ini.j2
@@ -15,3 +15,7 @@ xdebug.remote_autostart={{ php_xdebug_remote_autostart }}
 xdebug.idekey="{{ php_xdebug_idekey }}"
 
 xdebug.max_nesting_level={{ php_xdebug_max_nesting_level }}
+
+xdebug.var_display_max_children={{ php_xdebug_var_display_max_children }}
+xdebug.var_display_max_data={{ php_xdebug_var_display_max_data }}
+xdebug.var_display_max_depth={{ php_xdebug_var_display_max_depth }}


### PR DESCRIPTION
var_display_max_children, var_display_max_data and var_display_max_depth [options](http://xdebug.org/docs/all_settings#var_display_max_data) support
