### PR TITLE
Check existing install before downloading Xdebug again.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,7 +5,7 @@
 - name: Download Xdebug.
   get_url:
     url: "http://xdebug.org/files/xdebug-{{ php_xdebug_version }}.tgz"
-    dest: "{{ workspace }}"
+    dest: "{{ workspace }}/xdebug-{{ php_xdebug_version }}.tgz"
 
 - name: Untar Xdebug.
   command: >


### PR DESCRIPTION
Avoid downloading Xdebug again when the configured version is already installed.

Note that if the version changes it will download the new version and install.