### PR TITLE
Update Xdebug from 2.2.5 to 2.3.3.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 workspace: /root
 
-php_xdebug_version: 2.2.5
+php_xdebug_version: 2.3.3
 
 php_xdebug_coverage_enable: 1
 php_xdebug_default_enable: 1


### PR DESCRIPTION
Xdebug 2.3.1 and lower contain bugs that cause segfaults during debugging sessions. To fix this, we'll need 2.3.2 at least, but seeing as 2.3.3 is the latest stable release, it makes sense to upgrade to that version straight away.