### PR TITLE
PHP-7.0-compatible sources

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -14,18 +14,22 @@
     - make
   when: ansible_os_family == 'Debian'
 
+# PHP7.0-compatible Xdebug is athttps://xdebug.org/files/xdebug-2.4.0.tgz
+# PHP5.6-compatible Xdebug is at https://xdebug.org/files/xdebug-2.2.4.tgz
+
 - name: Download Xdebug.
   get_url:
-    url: "https://github.com/xdebug/xdebug/archive/{{ php_xdebug_version }}.tar.gz"
-    dest: "{{ workspace }}/xdebug-{{ php_xdebug_version }}.tar.gz"
+    url: "https://xdebug.org/files/xdebug-{{ php_xdebug_version }}.tgz"
+    dest: "{{ workspace }}/xdebug-{{ php_xdebug_version }}.tgz"
 
 # TODO: In 2.0, we can set the 'src' to the URL from the get_url task above and
 # cut out one extra task :)
 - name: Untar Xdebug.
   unarchive:
-    src: "{{ workspace }}/xdebug-{{ php_xdebug_version }}.tar.gz"
+    src: "{{ workspace }}/xdebug-{{ php_xdebug_version }}.tgz"
     dest: "{{ workspace }}"
     copy: no
+
 
 - name: Build Xdebug.
   shell: >


### PR DESCRIPTION
This will pick up an `debug` source that works with PHP7.0. Did the location of sources change since Xdebug 2.2.4?

Anyway, this works if your `config.yml` says something like:

    php_version: "7.0"  

and

     installed_extras:
        - adminer
        - drupalconsole
        # - mailhog
        # - memcached
        - nodejs
        - pimpmylog
        # - redis
        # - ruby
        - selenium
        # - solr
        # - varnish
        - xdebug
        # - xhprof