### PR TITLE
Only build and install xdebug if required.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,31 +2,29 @@
 - name: Include OS-specific variables.
   include_vars: "{{ ansible_os_family }}.yml"
 
+- name: Check if the requested version of xdebug is already installed
+  shell: "diff -s {{ workspace }}/xdebug-{{ php_xdebug_version }}/modules/xdebug.so {{ php_xdebug_module_path }}/xdebug.so 2>/dev/null"
+  failed_when: false
+  register: is_installed
+
 - name: Ensure dependencies for building from source are installed (RedHat).
   yum: "pkg={{ item }} state=installed"
   with_items:
     - make
-  when: ansible_os_family == 'RedHat'
+  when: ansible_os_family == 'RedHat' and not is_installed.stdout
 
 - name: Ensure dependencies for building from source are installed (Debian).
   apt: "pkg={{ item }} state=installed"
   with_items:
     - make
-  when: ansible_os_family == 'Debian'
+  when: ansible_os_family == 'Debian' and not is_installed.stdout
 
-- name: Download Xdebug.
-  get_url:
-    url: "https://xdebug.org/files/xdebug-{{ php_xdebug_version }}.tgz"
-    dest: "{{ workspace }}/xdebug-{{ php_xdebug_version }}.tgz"
-
-# TODO: In 2.0, we can set the 'src' to the URL from the get_url task above and
-# cut out one extra task :)
 - name: Untar Xdebug.
   unarchive:
-    src: "{{ workspace }}/xdebug-{{ php_xdebug_version }}.tgz"
+    src: "https://xdebug.org/files/xdebug-{{ php_xdebug_version }}.tgz"
     dest: "{{ workspace }}"
     copy: no
-
+  when: not is_installed.stdout
 
 - name: Build Xdebug.
   shell: >
@@ -38,6 +36,7 @@
     - ./configure
     - make
   notify: restart webserver
+  when: not is_installed.stdout
 
 - name: Ensure Xdebug module path exists.
   file:
@@ -46,11 +45,13 @@
     owner: root
     group: root
     mode: 0755
+  when: not is_installed.stdout
 
 - name: Move Xdebug module into place.
   shell: >
     cp {{ workspace }}/xdebug-{{ php_xdebug_version }}/modules/xdebug.so {{ php_xdebug_module_path }}/xdebug.so
-    creates={{ php_xdebug_module_path }}/xdebug.so
+  when: not is_installed.stdout
   notify: restart webserver
+
 
 - include: configure.yml


### PR DESCRIPTION
This role currently always builds xdebug but will not upgrade.

This PR corrects both situations.  It will now only build if the requested version is not installed.  Also it will ensure the requested version is installed in the correct location.

Also made the change for the "TODO: In 2.0, we can set the 'src' to the URL from the get_url task above and cut out one extra task :)"
