### PR TITLE
Allow xdebug module path & file name to be overridden.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,6 +2,16 @@
 - name: Include OS-specific variables.
   include_vars: "{{ ansible_os_family }}.yml"
 
+- name: Define php_xdebug_module_path.
+  set_fact:
+    php_xdebug_module_path: "{{ __php_xdebug_module_path }}"
+  when: php_xdebug_module_path is not defined
+
+- name: Define php_xdebug_config_filename.
+  set_fact:
+    php_xdebug_config_filename: "{{ __php_xdebug_config_filename }}"
+  when: php_xdebug_config_filename is not defined
+
 - name: Ensure dependencies for building from source are installed (RedHat).
   yum: "pkg={{ item }} state=installed"
   with_items:

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,3 +1,3 @@
 ---
-php_xdebug_module_path: /usr/lib/php5/modules
-php_xdebug_config_filename: 20-xdebug.ini
+__php_xdebug_module_path: /usr/lib/php5/modules
+__php_xdebug_config_filename: 20-xdebug.ini

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,3 +1,3 @@
 ---
-php_xdebug_module_path: /usr/lib64/php/modules
-php_xdebug_config_filename: xdebug.ini
+__php_xdebug_module_path: /usr/lib64/php/modules
+__php_xdebug_config_filename: xdebug.ini


### PR DESCRIPTION
Helps with switching PHP versions -- see https://github.com/geerlingguy/drupal-vm/pull/714
