### PR TITLE
Followup #30: Only build and install xdebug if required

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -17,4 +17,3 @@ php_xdebug_remote_autostart: "false"
 php_xdebug_idekey: sublime.xdebug
 
 php_xdebug_max_nesting_level: 256
-

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,23 +12,29 @@
     php_xdebug_config_filename: "{{ __php_xdebug_config_filename }}"
   when: php_xdebug_config_filename is not defined
 
+- name: Check if the requested version of xdebug is already installed
+  shell: "diff -s {{ workspace }}/xdebug-{{ php_xdebug_version }}/modules/xdebug.so {{ php_xdebug_module_path }}/xdebug.so 2>/dev/null"
+  failed_when: false
+  register: is_installed
+
 - name: Ensure dependencies for building from source are installed (RedHat).
   yum: "name={{ item }} state=installed"
   with_items:
     - '@development'
-  when: ansible_os_family == 'RedHat'
+  when: ansible_os_family == 'RedHat' and not is_installed.stdout
 
 - name: Ensure dependencies for building from source are installed (Debian).
   apt: "name={{ item }} state=installed"
   with_items:
     - build-essential
-  when: ansible_os_family == 'Debian'
+  when: ansible_os_family == 'Debian' and not is_installed.stdout
 
 - name: Untar Xdebug.
   unarchive:
     src: "https://xdebug.org/files/xdebug-{{ php_xdebug_version }}.tgz"
     dest: "{{ workspace }}"
     copy: no
+  when: not is_installed.stdout
 
 - name: Build Xdebug.
   shell: >
@@ -40,6 +46,7 @@
     - ./configure
     - make
   notify: restart webserver
+  when: not is_installed.stdout
 
 - name: Ensure Xdebug module path exists.
   file:
@@ -48,11 +55,12 @@
     owner: root
     group: root
     mode: 0755
+  when: not is_installed.stdout
 
 - name: Move Xdebug module into place.
   shell: >
     cp {{ workspace }}/xdebug-{{ php_xdebug_version }}/modules/xdebug.so {{ php_xdebug_module_path }}/xdebug.so
-    creates={{ php_xdebug_module_path }}/xdebug.so
+  when: not is_installed.stdout
   notify: restart webserver
 
 - include: configure.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,8 +12,13 @@
     php_xdebug_config_filename: "{{ __php_xdebug_config_filename }}"
   when: php_xdebug_config_filename is not defined
 
+- name: Define php_xdebug_source_path.
+  set_fact:
+    php_xdebug_source_path: "{{ workspace }}/xdebug-{{ php_xdebug_version }}-php{{ php_version|default('') }}"
+  when: php_xdebug_source_path is not defined
+
 - name: Check if the requested version of xdebug is already installed
-  shell: "diff -s {{ workspace }}/xdebug-{{ php_xdebug_version }}/modules/xdebug.so {{ php_xdebug_module_path }}/xdebug.so 2>/dev/null"
+  shell: "diff -s {{ php_xdebug_source_path }}/modules/xdebug.so {{ php_xdebug_module_path }}/xdebug.so 2>/dev/null"
   failed_when: false
   register: is_installed
 
@@ -36,11 +41,18 @@
     copy: no
   when: not is_installed.stdout
 
+- name: Copy Xdebug source to a php version -specific path.
+  copy:
+    src: "{{ workspace }}/xdebug-{{ php_xdebug_version }}"
+    dest: "{{ php_xdebug_source_path }}"
+    remote_src: yes
+  when: not is_installed.stdout
+
 - name: Build Xdebug.
   shell: >
     {{ item }}
-    chdir={{ workspace }}/xdebug-{{ php_xdebug_version }}
-    creates={{ workspace }}/xdebug-{{ php_xdebug_version }}/modules/xdebug.so
+    chdir={{ php_xdebug_source_path }}
+    creates={{ php_xdebug_source_path }}/modules/xdebug.so
   with_items:
     - phpize
     - ./configure
@@ -58,8 +70,10 @@
   when: not is_installed.stdout
 
 - name: Move Xdebug module into place.
-  shell: >
-    cp {{ workspace }}/xdebug-{{ php_xdebug_version }}/modules/xdebug.so {{ php_xdebug_module_path }}/xdebug.so
+  copy:
+    src: "{{ php_xdebug_source_path }}/modules/xdebug.so"
+    dest: "{{ php_xdebug_module_path }}/xdebug.so"
+    remote_src: yes
   when: not is_installed.stdout
   notify: restart webserver
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -42,10 +42,9 @@
   when: not is_installed.stdout
 
 - name: Copy Xdebug source to a php version -specific path.
-  copy:
-    src: "{{ workspace }}/xdebug-{{ php_xdebug_version }}"
-    dest: "{{ php_xdebug_source_path }}"
-    remote_src: yes
+  shell: >
+    cp -r {{ workspace }}/xdebug-{{ php_xdebug_version }} {{ php_xdebug_source_path }}
+    creates={{ php_xdebug_source_path }}
   when: not is_installed.stdout
 
 - name: Build Xdebug.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -19,33 +19,34 @@
 
 - name: Check if the requested version of xdebug is already installed
   shell: "diff -s {{ php_xdebug_source_path }}/modules/xdebug.so {{ php_xdebug_module_path }}/xdebug.so 2>/dev/null"
-  failed_when: false
   register: is_installed
+  failed_when: false
+  changed_when: is_installed.rc != 0
 
 - name: Ensure dependencies for building from source are installed (RedHat).
   yum: "name={{ item }} state=installed"
   with_items:
     - '@development'
-  when: ansible_os_family == 'RedHat' and not is_installed.stdout
+  when: ansible_os_family == 'RedHat' and is_installed.changed
 
 - name: Ensure dependencies for building from source are installed (Debian).
   apt: "name={{ item }} state=installed"
   with_items:
     - build-essential
-  when: ansible_os_family == 'Debian' and not is_installed.stdout
+  when: ansible_os_family == 'Debian' and is_installed.changed
 
 - name: Untar Xdebug.
   unarchive:
     src: "https://xdebug.org/files/xdebug-{{ php_xdebug_version }}.tgz"
     dest: "{{ workspace }}"
     copy: no
-  when: not is_installed.stdout
+  when: is_installed.changed
 
 - name: Copy Xdebug source to a php version -specific path.
   shell: >
     cp -r {{ workspace }}/xdebug-{{ php_xdebug_version }} {{ php_xdebug_source_path }}
     creates={{ php_xdebug_source_path }}
-  when: not is_installed.stdout
+  when: is_installed.changed
 
 - name: Build Xdebug.
   shell: >
@@ -57,7 +58,7 @@
     - ./configure
     - make
   notify: restart webserver
-  when: not is_installed.stdout
+  when: is_installed.changed
 
 - name: Ensure Xdebug module path exists.
   file:
@@ -66,14 +67,14 @@
     owner: root
     group: root
     mode: 0755
-  when: not is_installed.stdout
+  when: is_installed.changed
 
 - name: Move Xdebug module into place.
   copy:
     src: "{{ php_xdebug_source_path }}/modules/xdebug.so"
     dest: "{{ php_xdebug_module_path }}/xdebug.so"
     remote_src: yes
-  when: not is_installed.stdout
+  when: is_installed.changed
   notify: restart webserver
 
 - include: configure.yml


### PR DESCRIPTION
I rebased @joestewart PR and made the compiled extension php version specific (if there's no php_version variable defined, it still works).

What do you think about this type of pattern rather than changing `workspace`? I'm not sure what happens if one role changes the `workspace` variable, is it scoped within the role or does it bubble up to all roles?

See #30, #18, https://github.com/geerlingguy/drupal-vm/issues/1076#issuecomment-268988244