### PR TITLE
Remove xdebug.remote_handler setting

### DIFF
--- a/templates/xdebug.ini.j2
+++ b/templates/xdebug.ini.j2
@@ -8,7 +8,6 @@ xdebug.remote_enable={{ php_xdebug_remote_enable }}
 xdebug.remote_connect_back={{ php_xdebug_remote_connect_back }}
 xdebug.remote_host={{ php_xdebug_remote_host }}
 xdebug.remote_port={{ php_xdebug_remote_port }}
-xdebug.remote_handler=dbgp
 xdebug.remote_log={{ php_xdebug_remote_log }}
 xdebug.remote_autostart={{ php_xdebug_remote_autostart }}
 


### PR DESCRIPTION
According to the [xdebug documentation](https://xdebug.org/docs/all_settings) remote_handler is no longer necessary. By default the value is dbgp at Xdebug >=2.1