### PR TITLE
Introduce a dependency on the geerlinguy.php role

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,5 +1,6 @@
 ---
-dependencies: []
+dependencies:
+  - geerlingguy.php
 
 galaxy_info:
   author: geerlingguy


### PR DESCRIPTION
This role triggers a handler titled "restart webserver" as part of the
installation of xdebug, presumably so that the PHP runtime being used
can load the PHP extension. However, the role does not include any such
handler. In executing the role with ansible 2.3.0.1, this fails.

The readme documents a requirement on the geerlingguy.php role. That
role includes the handler for restarting the webserver. While that was
included in this ansible playbook, the handler still did not trigger.
However, ansible appears to allow triggering handlers across roles in
the case that there is an explicit dependency introduced on that role[1]

This commit introduces such a dependency, after which this issue is
resolved.

[1] https://stackoverflow.com/a/29297938/3897856