### PR TITLE
Allow building the xdebug extension on ubuntu 16.04

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -22,6 +22,7 @@
   apt: "name={{ item }} state=installed"
   with_items:
     - build-essential
+    - php-dev
   when: ansible_os_family == 'Debian'
 
 - name: Untar Xdebug.


### PR DESCRIPTION
This role pulls a PHP extension from the XDEBUG website and attempts to
compile it. In the Debian OS family it includes the build-essentials
package to pull down make, compilers etc to assist with this task,
however it does not pull down the phpize package; included as part of
the php-dev package, but otherwise not mandated by any of the
dependencies of this task.

This commit includes the php-dev package for the Debian OS family, so
that it can compile successfully.