### PR TITLE
Allow disabling xdebug for CLI SAPI on Debian/Ubuntu.

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,10 @@ The IDE key to use in the URL when making Xdebug requests (e.g. `http://example.
 
 The maximimum function nesting level before Xdebug bails and throws a fatal exception.
 
+    php_xdebug_cli_disable: no
+
+(Debian/Ubuntu ONLY) Disable xdebug for the CLI SAPI.
+
 ## Dependencies
 
   - geerlingguy.php

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -17,3 +17,5 @@ php_xdebug_idekey: sublime.xdebug
 
 php_xdebug_max_nesting_level: 256
 
+# Only used on Debian/Ubuntu.
+php_xdebug_cli_disable: no

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -6,7 +6,17 @@
     owner: root
     group: root
     mode: 0644
+  when: "'cli' not in item or ('cli' in item and not php_xdebug_cli_disable)"
   with_items: "{{ php_extension_conf_paths }}"
+  notify:
+    - restart webserver
+    - restart php-fpm
+
+- name: Disable xdebug for PHP CLI.
+  file:
+    path: "/etc/php/{{ php_version }}/cli/conf.d/{{ php_xdebug_config_filename }}"
+    state: absent
+  when: ansible_os_family == 'Debian' and php_xdebug_cli_disable
   notify:
     - restart webserver
     - restart php-fpm


### PR DESCRIPTION
Fixes #53