### PR TITLE
Bump default version to 2.7.0

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 workspace: /root
 
-php_xdebug_version: 2.6.0
+php_xdebug_version: 2.7.0
 
 php_xdebug_coverage_enable: 1
 php_xdebug_default_enable: 1


### PR DESCRIPTION
Xdebug 2.7.0 has been released: https://xdebug.org/#2019_03_06 It includes support for PHP 7.3

I tested this change by updating this var in a DrupalVM project and was able to install and configure Xdebug successfully:

![image](https://user-images.githubusercontent.com/202034/53892153-c2da3e00-3ff9-11e9-93ae-1d722211b98c.png)

(yes, I initially had xdebug disabled for CLI, but I fixed that before running `php -v` below:)

![image](https://user-images.githubusercontent.com/202034/53892476-5c095480-3ffa-11e9-91c2-5dcc5ed009e5.png)
