### PR TITLE
Add a subset of Xdebug settings for function traces.

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,42 @@ The IDE key to use in the URL when making Xdebug requests (e.g. `http://example.
 
 The maximimum function nesting level before Xdebug bails and throws a fatal exception.
 
+    php_xdebug_collect_assignments: 0
+
+This controls whether Xdebug should add variable assignments to function traces.
+
+    php_xdebug_collect_params: 0
+
+This controls whether Xdebug should collect the parameters passed to functions when a function call is recorded in either the function trace or the stack trace. Do not enable this without reading the [documentation](https://xdebug.org/docs/all_settings#collect_params).
+
+    php_xdebug_collect_return: 0
+
+This setting, defaulting to 0, controls whether Xdebug should write the return value of function calls to the trace files.
+
+    php_xdebug_show_mem_delta: 0
+
+When enabled, Xdebug's human-readable generated trace files will show the difference in memory usage between function calls.
+
+    php_xdebug_trace_enable_trigger: 0
+
+When set to 1, you can trigger the generation of trace files by using the XDEBUG_TRACE GET/POST parameter, or set a cookie with the name XDEBUG_TRACE.
+
+    php_xdebug_trace_format: 0
+
+Set this to 2 for the trace files to be generated in basic HTML instead of plain text. See the [documentation](https://xdebug.org/docs/all_settings#trace_format) for other options.
+
+    php_xdebug_trace_options: 0
+
+When set to '1' the trace files will be appended to, instead of being overwritten in subsequent requests.
+
+    php_xdebug_trace_output_dir: /tmp
+
+The directory where the tracing files will be written to, make sure that the user who the PHP will be running as has write permissions to that directory.
+
+    php_xdebug_trace_output_name: "trace.%c"
+
+This setting determines the name of the file that is used to dump traces into. See the [documentation](https://xdebug.org/docs/all_settings#trace_output_name) on how to specify the format.
+
     php_xdebug_cli_disable: false
 
 (Debian/Ubuntu ONLY) Disable xdebug for the CLI SAPI.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -17,5 +17,16 @@ php_xdebug_idekey: sublime.xdebug
 
 php_xdebug_max_nesting_level: 256
 
+php_xdebug_collect_assignments: 0
+php_xdebug_collect_params: 0
+php_xdebug_collect_return: 0
+
+php_xdebug_show_mem_delta: 0
+php_xdebug_trace_enable_trigger: 0
+php_xdebug_trace_format: 0
+php_xdebug_trace_options: 0
+php_xdebug_trace_output_dir: /tmp
+php_xdebug_trace_output_name: "trace.%c"
+
 # Only used on Debian/Ubuntu.
 php_xdebug_cli_disable: false

--- a/templates/xdebug.ini.j2
+++ b/templates/xdebug.ini.j2
@@ -14,3 +14,14 @@ xdebug.remote_autostart={{ php_xdebug_remote_autostart }}
 xdebug.idekey="{{ php_xdebug_idekey }}"
 
 xdebug.max_nesting_level={{ php_xdebug_max_nesting_level }}
+
+xdebug.collect_assignments={{ php_xdebug_collect_assignments }}
+xdebug.collect_params={{ php_xdebug_collect_params }}
+xdebug.collect_return={{ php_xdebug_collect_return }}
+
+xdebug.show_mem_delta={{ php_xdebug_show_mem_delta }}
+xdebug.trace_enable_trigger={{ php_xdebug_trace_enable_trigger }}
+xdebug.trace_format={{ php_xdebug_trace_format }}
+xdebug.trace_options={{ php_xdebug_trace_options }}
+xdebug.trace_output_dir={{ php_xdebug_trace_output_dir }}
+xdebug.trace_output_name={{ php_xdebug_trace_output_name }}


### PR DESCRIPTION
I've excluded options which relate to parsing the trace output with a tool, those related to a form of access control. I've tried to keep it to the minimum settings required for use with something like DrupalVM with access only from a local network.

I have tested this, and it works as expected thus far.

Please let me know if the documentation is sufficient.