### PR TITLE
Update vars and template to support xdebug 3.x

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -19,3 +19,12 @@ php_xdebug_max_nesting_level: 256
 
 # Only used on Debian/Ubuntu.
 php_xdebug_cli_disable: false
+
+# Configuration for Xdebug version 3 and up.
+php_xdebug_mode: "develop"
+
+php_xdebug_discover_client_host: "false"
+php_xdebug_client_host: localhost
+php_xdebug_client_port: "9003"
+php_xdebug_log: /tmp/xdebug.log
+php_xdebug_start_with_request: "default"

--- a/templates/xdebug.ini.j2
+++ b/templates/xdebug.ini.j2
@@ -1,6 +1,7 @@
 [XDebug]
 zend_extension="{{ php_xdebug_module_path }}/xdebug-{{ php_xdebug_version }}.so"
 
+{% if php_xdebug_version[:1]|int < 3 %}
 xdebug.coverage_enable={{ php_xdebug_coverage_enable }}
 xdebug.default_enable={{ php_xdebug_default_enable }}
 
@@ -10,6 +11,15 @@ xdebug.remote_host={{ php_xdebug_remote_host }}
 xdebug.remote_port={{ php_xdebug_remote_port }}
 xdebug.remote_log={{ php_xdebug_remote_log }}
 xdebug.remote_autostart={{ php_xdebug_remote_autostart }}
+{% else %}
+xdebug.mode={{ php_xdebug_mode }}
+
+xdebug.discover_client_host={{ php_xdebug_discover_client_host }}
+xdebug.client_host={{ php_xdebug_client_host }}
+xdebug.client_port={{ php_xdebug_client_port }}
+xdebug.log={{ php_xdebug_log }}
+xdebug.start_with_request={{ php_xdebug_start_with_request }}
+{% endif %}
 
 xdebug.idekey="{{ php_xdebug_idekey }}"
 


### PR DESCRIPTION
I have not updated the readme yet in case this is not the path we want to take.
This works as expected in my testing, (with drupal projects).



---
Resolves #65 